### PR TITLE
Simulations for 9 vs 13m trade study

### DIFF
--- a/sims/9vs13sims_FullArray_001/README.txt
+++ b/sims/9vs13sims_FullArray_001/README.txt
@@ -1,0 +1,11 @@
+The simulation in this directory aims to provide simulations and quantitative metric values for the 9m vs 13m trade study.  Specifically, this directory deals with the "full array" configuration.
+
+To set up the necessary environment for running the simulation, the user must first install the Python-based ngehtsim package.  The installation requires at least Python version 3.8, and it can be carried out using the requirements.txt document by running:
+
+> pip install -r requirements.txt
+
+This simulation is then run in two parts.
+
+The first part requires running the "gendata.py" script.  This script produces a number directories containing (u,v)-coverage plots and .uvfits files capturing simulations of M87 carried out under different weather instantiations.  A geometric model for the M87 near-horizon source structure is used, though the recovered metric values have been shown to be consistent with those produced using proprietary GRMHD+GRRT simulations for the source structure.  Note: The gendata.py script will take several hours to complete on a typical laptop or desktop.
+
+After gendata.py has finished running, the "compute_metrics_full_array.py" script should be run.  This script computes and prints out the various metric values appropriate for "full array" operations of the array, and it produces some comparison plots.

--- a/sims/9vs13sims_FullArray_001/compute_metrics_full_array.py
+++ b/sims/9vs13sims_FullArray_001/compute_metrics_full_array.py
@@ -1,0 +1,215 @@
+#######################################################
+# imports
+
+import numpy as np
+import ngehtsim.metrics as cm
+import ehtim as eh
+import glob
+
+#######################################################
+# looped quantities
+
+outdirs = ['./array_baseline_9m+128Gbps',
+           './array_option1_13m+128Gbps',
+           './array_option2_13m+64Gbps',
+           './array_option3a_13m+128Gbps_noSPM',
+           './array_option3b_13m+128Gbps_noLCO',
+           './array_option3c_13m+128Gbps_noCNI',
+           './array_option3d_13m+128Gbps_noJELM',
+           './array_option4a_13m+64Gbps_noSPM',
+           './array_option4b_13m+64Gbps_noLCO',
+           './array_option4c_13m+64Gbps_noCNI',
+           './array_option4d_13m+64Gbps_noJELM',
+           './array_option5_13m+128Gbps_noLCO_withLLA']
+
+#######################################################
+# compute filling fractions
+
+m_100_M87 = list()
+s_100_M87 = list()
+m_1000_M87 = list()
+s_1000_M87 = list()
+m_100_SgrA = list()
+s_100_SgrA = list()
+m_1000_SgrA = list()
+s_1000_SgrA = list()
+
+for idir, outdir in enumerate(outdirs):
+
+    filelist_86_M87 = np.sort(glob.glob(outdir+'/uvfits_M87/*86GHz*uvfits'))
+    filelist_230_M87 = np.sort(glob.glob(outdir+'/uvfits_M87/*230GHz*uvfits'))
+    filelist_345_M87 = np.sort(glob.glob(outdir+'/uvfits_M87/*345GHz*uvfits'))
+
+    ff100_M87 = np.zeros(len(filelist_86_M87))
+    ff1000_M87 = np.zeros(len(filelist_86_M87))
+    for i in range(len(filelist_86_M87)):
+        with eh.parloop.HiddenPrints():
+            obs_86 = eh.obsdata.load_uvfits(filelist_86_M87[i])
+            obs_230 = eh.obsdata.load_uvfits(filelist_230_M87[i])
+            obs_345 = eh.obsdata.load_uvfits(filelist_345_M87[i])
+        obs_230.data['time'] += 0.0001
+        obs_345.data['time'] += 0.0002
+        obs = eh.obsdata.merge_obs([obs_345,obs_230,obs_86],force_merge=True)
+        ff100_M87[i] = cm.calc_ff(obs,fov=100.0,longest_BL=14.66e9)
+        ff1000_M87[i] = cm.calc_ff(obs,fov=1000.0,longest_BL=2.06e9)
+    ff100mean_M87 = np.mean(ff100_M87)
+    ff100std_M87 = np.std(ff100_M87)
+    ff1000mean_M87 = np.mean(ff1000_M87)
+    ff1000std_M87 = np.std(ff1000_M87)
+    m_100_M87.append(ff100mean_M87)
+    s_100_M87.append(ff100std_M87)
+    m_1000_M87.append(ff1000mean_M87)
+    s_1000_M87.append(ff1000std_M87)
+
+    # print
+    print('-'*40)
+    print('M87 metrics for '+outdir+':')
+    print('FF100: '+str(ff100mean_M87)+' +/- '+str(ff100std_M87))
+    print('FF1000: '+str(ff1000mean_M87)+' +/- '+str(ff1000std_M87))
+    print('-'*40)
+
+    filelist_86_SgrA = np.sort(glob.glob(outdir+'/uvfits_SgrA/*86GHz*uvfits'))
+    filelist_230_SgrA = np.sort(glob.glob(outdir+'/uvfits_SgrA/*230GHz*uvfits'))
+    filelist_345_SgrA = np.sort(glob.glob(outdir+'/uvfits_SgrA/*345GHz*uvfits'))
+
+    ff100_SgrA = np.zeros(len(filelist_86_SgrA))
+    ff1000_SgrA = np.zeros(len(filelist_86_SgrA))
+    for i in range(len(filelist_86_SgrA)):
+        with eh.parloop.HiddenPrints():
+            obs_86 = eh.obsdata.load_uvfits(filelist_86_SgrA[i])
+            obs_230 = eh.obsdata.load_uvfits(filelist_230_SgrA[i])
+            obs_345 = eh.obsdata.load_uvfits(filelist_345_SgrA[i])
+        obs_230.data['time'] += 0.0001
+        obs_345.data['time'] += 0.0002
+        obs = eh.obsdata.merge_obs([obs_345,obs_230,obs_86],force_merge=True)
+        ff100_SgrA[i] = cm.calc_ff(obs,fov=100.0,longest_BL=14.66e9)
+        ff1000_SgrA[i] = cm.calc_ff(obs,fov=1000.0,longest_BL=2.06e9)
+    ff100mean_SgrA = np.mean(ff100_SgrA)
+    ff100std_SgrA = np.std(ff100_SgrA)
+    ff1000mean_SgrA = np.mean(ff1000_SgrA)
+    ff1000std_SgrA = np.std(ff1000_SgrA)
+    m_100_SgrA.append(ff100mean_SgrA)
+    s_100_SgrA.append(ff100std_SgrA)
+    m_1000_SgrA.append(ff1000mean_SgrA)
+    s_1000_SgrA.append(ff1000std_SgrA)
+
+    # print
+    print('-'*40)
+    print('Sgr A* metrics for '+outdir+':')
+    print('FF100: '+str(ff100mean_SgrA)+' +/- '+str(ff100std_SgrA))
+    print('FF1000: '+str(ff1000mean_SgrA)+' +/- '+str(ff1000std_SgrA))
+    print('-'*40)
+
+#######################################################
+# plot things
+
+import matplotlib.pyplot as plt
+
+plt.rcParams.update({
+    "text.usetex": True,
+    "font.family": "serif",
+    "font.serif": ["Times"],
+    "font.size": 10})
+
+#######################################################
+# plot M87
+
+base_m_100 = m_100_M87[0]
+base_s_100 = s_100_M87[0]
+base_m_1000 = m_1000_M87[0]
+base_s_1000 = s_1000_M87[0]
+
+m_100 = np.array(m_100_M87[1:])
+s_100 = np.array(s_100_M87[1:])
+m_1000 = np.array(m_1000_M87[1:])
+s_1000 = np.array(s_1000_M87[1:])
+
+m_100_frac = 100.0*((m_100 - base_m_100)/base_m_100)
+s_100_frac = 100.0*(s_100/base_m_100)
+m_1000_frac = 100.0*((m_1000 - base_m_1000)/base_m_1000)
+s_1000_frac = 100.0*(s_1000/base_m_1000)
+
+s_100_frac_base = 100.0*(base_s_100 / base_m_100)
+s_1000_frac_base = 100.0*(base_s_1000 / base_m_1000)
+
+fig = plt.figure(figsize=(8,2))
+ax1 = fig.add_axes([0.1,0.1,0.8,0.4])
+ax2 = fig.add_axes([0.1,0.5,0.8,0.4])
+
+x = np.linspace(1.0,len(m_100),len(m_100))
+
+ax2.fill_between([0,20],[-s_100_frac_base,-s_100_frac_base],[s_100_frac_base,s_100_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax2.plot([0,20],[0.0,0.0],'k--')
+ax2.errorbar(x,m_100_frac,yerr=s_100_frac,fmt='bo',markersize=4)
+
+ax1.fill_between([0,20],[-s_1000_frac_base,-s_1000_frac_base],[s_1000_frac_base,s_1000_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax1.plot([0,20],[0.0,0.0],'k--')
+ax1.errorbar(x,m_1000_frac,yerr=s_1000_frac,fmt='bo',markersize=4)
+
+ax1.set_xlim(0,len(m_100)+1)
+ax1.set_ylim(-11,11)
+ax2.set_xlim(0,len(m_100)+1)
+ax2.set_ylim(-30,30)
+
+ax1.set_ylabel(r'$\Delta$FF1000 (\%)')
+ax2.set_ylabel(r'$\Delta$FF100 (\%)')
+
+ax1.set_xticks(x)
+ax2.set_xticks(x)
+ax1.set_xticklabels(['Option 1', 'Option 2', 'Option 3a\n(no SPM)', 'Option 3b\n(no LCO)', 'Option 3c\n(no CNI)', 'Option 3d\n(no JELM)', 'Option 4a\n(no SPM)', 'Option 4b\n(no LCO)', 'Option 4c\n(no CNI)', 'Option 4d\n(no JELM)', 'Option 5'],rotation=60,ha='center')
+ax2.set_xticklabels([])
+
+plt.savefig('comparison_M87.png',dpi=300,bbox_inches='tight')
+plt.close()
+
+#######################################################
+# plot SgrA
+
+base_m_100 = m_100_SgrA[0]
+base_s_100 = s_100_SgrA[0]
+base_m_1000 = m_1000_SgrA[0]
+base_s_1000 = s_1000_SgrA[0]
+
+m_100 = np.array(m_100_SgrA[1:])
+s_100 = np.array(s_100_SgrA[1:])
+m_1000 = np.array(m_1000_SgrA[1:])
+s_1000 = np.array(s_1000_SgrA[1:])
+
+m_100_frac = 100.0*((m_100 - base_m_100)/base_m_100)
+s_100_frac = 100.0*(s_100/base_m_100)
+m_1000_frac = 100.0*((m_1000 - base_m_1000)/base_m_1000)
+s_1000_frac = 100.0*(s_1000/base_m_1000)
+
+s_100_frac_base = 100.0*(base_s_100 / base_m_100)
+s_1000_frac_base = 100.0*(base_s_1000 / base_m_1000)
+
+fig = plt.figure(figsize=(8,2))
+ax1 = fig.add_axes([0.1,0.1,0.8,0.4])
+ax2 = fig.add_axes([0.1,0.5,0.8,0.4])
+
+x = np.linspace(1.0,len(m_100),len(m_100))
+
+ax2.fill_between([0,20],[-s_100_frac_base,-s_100_frac_base],[s_100_frac_base,s_100_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax2.plot([0,20],[0.0,0.0],'k--')
+ax2.errorbar(x,m_100_frac,yerr=s_100_frac,fmt='bo',markersize=4)
+
+ax1.fill_between([0,20],[-s_1000_frac_base,-s_1000_frac_base],[s_1000_frac_base,s_1000_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax1.plot([0,20],[0.0,0.0],'k--')
+ax1.errorbar(x,m_1000_frac,yerr=s_1000_frac,fmt='bo',markersize=4)
+
+ax1.set_xlim(0,len(m_100)+1)
+ax1.set_ylim(-30,30)
+ax2.set_xlim(0,len(m_100)+1)
+ax2.set_ylim(-15,15)
+
+ax1.set_ylabel(r'$\Delta$FF1000 (\%)')
+ax2.set_ylabel(r'$\Delta$FF100 (\%)')
+
+ax1.set_xticks(x)
+ax2.set_xticks(x)
+ax1.set_xticklabels(['Option 1', 'Option 2', 'Option 3a\n(no SPM)', 'Option 3b\n(no LCO)', 'Option 3c\n(no CNI)', 'Option 3d\n(no JELM)', 'Option 4a\n(no SPM)', 'Option 4b\n(no LCO)', 'Option 4c\n(no CNI)', 'Option 4d\n(no JELM)', 'Option 5'],rotation=60,ha='center')
+ax2.set_xticklabels([])
+
+plt.savefig('comparison_SgrA.png',dpi=300,bbox_inches='tight')
+plt.close()
+

--- a/sims/9vs13sims_FullArray_001/gendata.py
+++ b/sims/9vs13sims_FullArray_001/gendata.py
@@ -1,0 +1,575 @@
+#######################################################
+# imports
+
+import numpy as np
+import matplotlib.pyplot as plt
+import ngehtsim.obs.obs_generator as og
+import ngehtsim.metrics as cm
+import ehtim as eh
+import ehtim.scattering as so
+import os
+
+#######################################################
+# looped quantities
+
+outdirs = ['./array_baseline_9m+128Gbps',
+           './array_option1_13m+128Gbps',
+           './array_option2_13m+64Gbps',
+           './array_option3a_13m+128Gbps_noSPM',
+           './array_option3b_13m+128Gbps_noLCO',
+           './array_option3c_13m+128Gbps_noCNI',
+           './array_option3d_13m+128Gbps_noJELM',
+           './array_option4a_13m+64Gbps_noSPM',
+           './array_option4b_13m+64Gbps_noLCO',
+           './array_option4c_13m+64Gbps_noCNI',
+           './array_option4d_13m+64Gbps_noJELM',
+           './array_option5_13m+128Gbps_noLCO_withLLA']
+
+sitess = [['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','KP','LAS','LMT','NOEMA','OVRO','SMA','SMT','SPT'],
+          ['ALMA','APEX','BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT']]
+
+dish_diameters = [9.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0]
+
+bandwidths = [16.0,
+              16.0,
+              8.0,
+              16.0,
+              16.0,
+              16.0,
+              16.0,
+              8.0,
+              8.0,
+              8.0,
+              8.0,
+              16.0]
+
+#######################################################
+# make source model for M87
+
+F0 = 0.6
+f0 = 0.9
+f1 = 0.1
+alpha = 15.0
+alpha2 = 1.5
+
+mod = eh.model.Model()
+mod = mod.add_thick_mring(F0=f0*F0,
+                          d=42.0*eh.RADPERUAS,
+                          alpha=alpha*eh.RADPERUAS,
+                          beta_list=[-0.4])
+mod = mod.add_thick_mring(F0=f1*F0,
+                          d=42.0*eh.RADPERUAS,
+                          alpha=alpha2*eh.RADPERUAS,
+                          beta_list=[-0.4])
+
+# save as image
+im = mod.make_image(500.0*eh.RADPERUAS,npix=512)
+im.save_fits('./M87.fits')
+
+#######################################################
+# make source model for Sgr A*
+
+F0 = 2.5
+f0 = 0.9
+d = 52.0
+alpha = 20.0
+b1a = 0.15
+b2a = 0.06
+b3a = 0.25
+b4a = 0.13
+b1p = 0.0
+b2p = -2.3
+b3p = 0.5
+b4p = -1.4
+
+alpha1 = 2.0
+f1 = 0.1
+
+beta1 = b1a*np.exp((1j)*(b1p*np.pi))
+beta2 = b2a*np.exp((1j)*(b2p*np.pi))
+beta3 = b3a*np.exp((1j)*(b3p*np.pi))
+beta4 = b4a*np.exp((1j)*(b4p*np.pi))
+stretch = 1.2
+stretch_PA = (np.pi/2.0) - 0.2
+
+mod = eh.model.Model()
+mod = mod.add_stretched_thick_mring(F0=f0*F0,
+                                    d=d*eh.RADPERUAS,
+                                    alpha=alpha*eh.RADPERUAS,
+                                    x0=0.0,
+                                    y0=0.0,
+                                    beta_list=[beta1,beta2,beta3,beta4],
+                                    stretch=stretch,
+                                    stretch_PA=stretch_PA)
+mod = mod.add_stretched_thick_mring(F0=f1*F0,
+                                    d=d*eh.RADPERUAS,
+                                    alpha=alpha1*eh.RADPERUAS,
+                                    x0=0.0,
+                                    y0=0.0,
+                                    beta_list=[beta1,beta2,beta3,beta4],
+                                    stretch=1.0,
+                                    stretch_PA=stretch_PA)
+
+
+# save as image
+im = mod.make_image(1000.0*eh.RADPERUAS,npix=1024)
+im.RA = 17.761122
+im.DEC = -29.00781
+im.source = 'SgrA'
+
+im.rf = 86.0e9
+im_scatt = sm.Scatter(im)
+im_scatt.save_fits('SgrA_86GHz.fits')
+
+im.rf = 230.0e9
+im_scatt = sm.Scatter(im)
+im_scatt.save_fits('SgrA_230GHz.fits')
+
+im.rf = 345.0e9
+im_scatt = sm.Scatter(im)
+im_scatt.save_fits('SgrA_345GHz.fits')
+
+#######################################################
+# primary settings
+
+Nweather = 100
+SNR_cut = 3.0
+
+freqs = [86.0, 230.0, 345.0]
+input_models_M87 = ['./M87.fits', './M87.fits', './M87.fits']
+input_models_SgrA = ['./SgrA_86GHz.fits', './SgrA_230GHz.fits', './SgrA_345GHz.fits']
+
+receiver_configuration_overrides = {'ALMA': ['Band7'],
+                                    'APEX': ['Band7'],
+                                    'BAJA': ['Band3', 'Band6', 'Band7'],
+                                    'CNI': ['Band3', 'Band6', 'Band7'],
+                                    'GLT': ['Band3', 'Band6', 'Band7'],
+                                    'HAY': ['Band3', 'Band6'],
+                                    'IRAM': ['Band7'],
+                                    'JCMT': ['Band3', 'Band6', 'Band7'],
+                                    'JELM': ['Band3', 'Band6', 'Band7'],
+                                    'KP': ['Band3', 'Band6'],
+                                    'LAS': ['Band3', 'Band6', 'Band7'],
+                                    'LMT': ['Band3', 'Band6', 'Band7'],
+                                    'NOEMA': ['Band7'],
+                                    'OVRO': ['Band3', 'Band6'],
+                                    'SMA': ['Band7'],
+                                    'SMT': ['Band3', 'Band6', 'Band7'],
+                                    'SPT': ['Band3', 'Band6', 'Band7']}
+
+# overrides
+T_R_overrides = {'ALMA': {'Band7': 75.0},
+                 'APEX': {'Band7': 75.0},
+                 'GLT': {'Band7': 75.0},
+                 'IRAM': {'Band7': 85.0},
+                 'JCMT': {'Band7': 105.0},
+                 'LMT': {'Band7': 75.0},
+                 'NOEMA': {'Band7': 85.0},
+                 'SMA': {'Band7': 130.0},
+                 'SMT': {'Band7': 150.0}}
+
+bandwidth_overrides = {'ALMA': {'Band7': 4.0},
+                       'APEX': {'Band7': 4.0},
+                       'IRAM': {'Band7': 4.0},
+                       'NOEMA': {'Band7': 4.0},
+                       'SMA': {'Band7': 4.0}}
+
+# specify the DSB stations
+sideband_ratio_overrides = {'SMA': {'Band7': 1.0},
+                            'SMT': {'Band7': 1.0}}
+
+#######################################################
+# run multiple weather instantiations
+
+for idir in range(len(outdirs)):
+
+    # grab current parameters
+    outdir = outdirs[idir]
+    sites = sitess[idir]
+    dish_diameter = dish_diameters[idir]
+    bandwidth = bandwidths[idir]
+
+    # make output directory
+    os.makedirs(outdir,exist_ok=True)
+    os.makedirs(outdir+'/uvfits_M87',exist_ok=True)
+    os.makedirs(outdir+'/uvfits_SgrA',exist_ok=True)
+
+    #######################################################
+    # M87 simulations
+
+    # update settings and overrides
+    settings = {'model_file': input_models_M87[-1],
+                'sites': sites,
+                'source': 'M87',
+                'frequency': freqs[-1],
+                'bandwidth': bandwidth,
+                'month': 'Apr',
+                'day': 15,
+                'year': 2021,
+                't_start': 0.0,
+                'dt': 24.0,
+                't_int': 300.0,
+                't_rest': 600.0,
+                'D_new': dish_diameter,
+                'fringe_finder': ['fringegroups', [5., 5.]],
+                'weather': 'random'}
+
+    D_overrides = {'BAJA': dish_diameter,
+                   'CNI': dish_diameter,
+                   'JELM': dish_diameter,
+                   'LAS': dish_diameter}
+
+    # run multiple weather instantiations
+    obslist_M87 = list()
+    fflist = list()
+    for i in range(Nweather):
+        print(i)
+
+        settings.update({'random_seed': 101 + i})
+        obsgen = og.obs_generator(settings,
+                              D_overrides=D_overrides,
+                              receiver_configuration_overrides=receiver_configuration_overrides,
+                              T_R_overrides=T_R_overrides,
+                              bandwidth_overrides=bandwidth_overrides,
+                              sideband_ratio_overrides=sideband_ratio_overrides)
+        obslist_here = obsgen.make_obs_mf(freqs,input_models_M87,addnoise=False,addgains=False)
+
+        if (SNR_cut > 0.0):
+            obslist_here[0] = obslist_here[0].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[1] = obslist_here[1].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[2] = obslist_here[2].flag_low_snr(snr_cut=SNR_cut).copy()
+
+        obslist_M87.append(obslist_here)
+
+        ff86 = cm.calc_ff(obslist_here[0],fov=100.0,longest_BL=14.66e9)
+        ff230 = cm.calc_ff(obslist_here[1],fov=100.0,longest_BL=14.66e9)
+        ff345 = cm.calc_ff(obslist_here[2],fov=100.0,longest_BL=14.66e9)
+        fflist.append([ff86,ff230,ff345])
+
+        # save uvfits
+        obslist_M87[i][0].save_uvfits(outdir+'/uvfits_M87/obs_86GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][1].save_uvfits(outdir+'/uvfits_M87/obs_230GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][2].save_uvfits(outdir+'/uvfits_M87/obs_345GHz_'+str(i).zfill(4)+'.uvfits')
+
+    # no noise obs
+    settings.update({'frequency': 86.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_86 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_86 = obsgen_nonoise_86.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_86 = obs_nonoise_86.data['u'] / (1.0e9)
+    v_nonoise_86 = obs_nonoise_86.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 230.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_230 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_230 = obsgen_nonoise_230.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_230 = obs_nonoise_230.data['u'] / (1.0e9)
+    v_nonoise_230 = obs_nonoise_230.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 345.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_345 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_345 = obsgen_nonoise_345.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_345 = obs_nonoise_345.data['u'] / (1.0e9)
+    v_nonoise_345 = obs_nonoise_345.data['v'] / (1.0e9)
+
+    #################
+    # plot
+
+    fig = plt.figure(figsize=(4,4))
+    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+
+    weight_86 = np.zeros_like(u_nonoise_86)
+    for j in range(Nweather):
+        obshere_86 = obslist_M87[j][0].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+        obshere_86 = obslist_M87[j][0].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+    weight_86 /= Nweather
+
+    weight_230 = np.zeros_like(u_nonoise_230)
+    for j in range(Nweather):
+        obshere_230 = obslist_M87[j][1].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+        obshere_230 = obslist_M87[j][1].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+    weight_230 /= Nweather
+
+    weight_345 = np.zeros_like(u_nonoise_345)
+    for j in range(Nweather):
+        obshere_345 = obslist_M87[j][2].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+        obshere_345 = obslist_M87[j][2].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+    weight_345 /= Nweather
+
+    for i in range(len(u_nonoise_345)):
+        ax.plot([u_nonoise_345[i]],[v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+        ax.plot([-u_nonoise_345[i]],[-v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+    for i in range(len(u_nonoise_230)):
+        ax.plot([u_nonoise_230[i]],[v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+        ax.plot([-u_nonoise_230[i]],[-v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+    for i in range(len(u_nonoise_86)):
+        ax.plot([u_nonoise_86[i]],[v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+        ax.plot([-u_nonoise_86[i]],[-v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+
+    # dummy legend point
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,label='345 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,label='230 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,label='86 GHz')
+    ax.legend(loc='lower left',fontsize=8)
+
+    ax.set_xlim(15,-15)
+    ax.set_ylim(-15,15)
+
+    ax.set_xlabel(r'$u$ (G$\lambda$)')
+    ax.set_ylabel(r'$v$ (G$\lambda$)')
+
+    ax.grid(linewidth=0.5,color='gray',alpha=0.2,linestyle='--')
+
+    plt.savefig(outdir+'/coverage_M87.png',dpi=300,bbox_inches='tight')
+    plt.close()
+
+    #################
+    # fill fraction
+
+    ffmeans = np.mean(np.array(fflist),axis=0)
+    ffstds = np.std(np.array(fflist),axis=0)
+
+    ff_86 = ffmeans[0]
+    ff_230 = ffmeans[1]
+    ff_345 = ffmeans[2]
+
+    print('-'*40)
+    print('M87 FF at 86 GHz: '+str(ff_86)+' +/- '+str(ffstds[0]))
+    print('M87 FF at 230 GHz: '+str(ff_230)+' +/- '+str(ffstds[1]))
+    print('M87 FF at 345 GHz: '+str(ff_345)+' +/- '+str(ffstds[2]))
+    print('-'*40)
+
+    #######################################################
+    # Sgr A* simulations
+
+    # update settings and overrides
+    settings = {'model_file': input_models_SgrA[-1],
+                'sites': sites,
+                'source': 'SgrA',
+                'frequency': freqs[-1],
+                'bandwidth': bandwidth,
+                'month': 'Apr',
+                'day': 15,
+                'year': 2021,
+                't_start': 0.0,
+                'dt': 24.0,
+                't_int': 300.0,
+                't_rest': 600.0,
+                'D_new': dish_diameter,
+                'fringe_finder': ['fringegroups', [5., 5.]],
+                'weather': 'random'}
+
+    D_overrides = {'BAJA': dish_diameter,
+                   'CNI': dish_diameter,
+                   'JELM': dish_diameter,
+                   'LAS': dish_diameter}
+
+    # run multiple weather instantiations
+    obslist_M87 = list()
+    fflist = list()
+    for i in range(Nweather):
+        print(i)
+
+        settings.update({'random_seed': 101 + i})
+        obsgen = og.obs_generator(settings,
+                              D_overrides=D_overrides,
+                              receiver_configuration_overrides=receiver_configuration_overrides,
+                              T_R_overrides=T_R_overrides,
+                              bandwidth_overrides=bandwidth_overrides,
+                              sideband_ratio_overrides=sideband_ratio_overrides)
+        obslist_here = obsgen.make_obs_mf(freqs,input_models_SgrA,addnoise=False,addgains=False)
+
+        if (SNR_cut > 0.0):
+            obslist_here[0] = obslist_here[0].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[1] = obslist_here[1].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[2] = obslist_here[2].flag_low_snr(snr_cut=SNR_cut).copy()
+
+        obslist_M87.append(obslist_here)
+
+        ff86 = cm.calc_ff(obslist_here[0],fov=100.0,longest_BL=14.66e9)
+        ff230 = cm.calc_ff(obslist_here[1],fov=100.0,longest_BL=14.66e9)
+        ff345 = cm.calc_ff(obslist_here[2],fov=100.0,longest_BL=14.66e9)
+        fflist.append([ff86,ff230,ff345])
+
+        # save uvfits
+        obslist_M87[i][0].save_uvfits(outdir+'/uvfits_M87/obs_86GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][1].save_uvfits(outdir+'/uvfits_M87/obs_230GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][2].save_uvfits(outdir+'/uvfits_M87/obs_345GHz_'+str(i).zfill(4)+'.uvfits')
+
+    # no noise obs
+    settings.update({'frequency': 86.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_86 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_86 = obsgen_nonoise_86.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_86 = obs_nonoise_86.data['u'] / (1.0e9)
+    v_nonoise_86 = obs_nonoise_86.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 230.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_230 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_230 = obsgen_nonoise_230.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_230 = obs_nonoise_230.data['u'] / (1.0e9)
+    v_nonoise_230 = obs_nonoise_230.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 345.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_345 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_345 = obsgen_nonoise_345.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_345 = obs_nonoise_345.data['u'] / (1.0e9)
+    v_nonoise_345 = obs_nonoise_345.data['v'] / (1.0e9)
+
+    #################
+    # plot
+
+    fig = plt.figure(figsize=(4,4))
+    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+
+    weight_86 = np.zeros_like(u_nonoise_86)
+    for j in range(Nweather):
+        obshere_86 = obslist_M87[j][0].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+        obshere_86 = obslist_M87[j][0].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+    weight_86 /= Nweather
+
+    weight_230 = np.zeros_like(u_nonoise_230)
+    for j in range(Nweather):
+        obshere_230 = obslist_M87[j][1].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+        obshere_230 = obslist_M87[j][1].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+    weight_230 /= Nweather
+
+    weight_345 = np.zeros_like(u_nonoise_345)
+    for j in range(Nweather):
+        obshere_345 = obslist_M87[j][2].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+        obshere_345 = obslist_M87[j][2].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+    weight_345 /= Nweather
+
+    for i in range(len(u_nonoise_345)):
+        ax.plot([u_nonoise_345[i]],[v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+        ax.plot([-u_nonoise_345[i]],[-v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+    for i in range(len(u_nonoise_230)):
+        ax.plot([u_nonoise_230[i]],[v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+        ax.plot([-u_nonoise_230[i]],[-v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+    for i in range(len(u_nonoise_86)):
+        ax.plot([u_nonoise_86[i]],[v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+        ax.plot([-u_nonoise_86[i]],[-v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+
+    # dummy legend point
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,label='345 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,label='230 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,label='86 GHz')
+    ax.legend(loc='lower left',fontsize=8)
+
+    ax.set_xlim(15,-15)
+    ax.set_ylim(-15,15)
+
+    ax.set_xlabel(r'$u$ (G$\lambda$)')
+    ax.set_ylabel(r'$v$ (G$\lambda$)')
+
+    ax.grid(linewidth=0.5,color='gray',alpha=0.2,linestyle='--')
+
+    plt.savefig(outdir+'/coverage_M87.png',dpi=300,bbox_inches='tight')
+    plt.close()
+
+    #################
+    # fill fraction
+
+    ffmeans = np.mean(np.array(fflist),axis=0)
+    ffstds = np.std(np.array(fflist),axis=0)
+
+    ff_86 = ffmeans[0]
+    ff_230 = ffmeans[1]
+    ff_345 = ffmeans[2]
+
+    print('-'*40)
+    print('Sgr A* FF at 86 GHz: '+str(ff_86)+' +/- '+str(ffstds[0]))
+    print('Sgr A* FF at 230 GHz: '+str(ff_230)+' +/- '+str(ffstds[1]))
+    print('Sgr A* FF at 345 GHz: '+str(ff_345)+' +/- '+str(ffstds[2]))
+    print('-'*40)
+

--- a/sims/9vs13sims_FullArray_001/requirements.txt
+++ b/sims/9vs13sims_FullArray_001/requirements.txt
@@ -1,0 +1,1 @@
+ngehtsim @ git+https://github.com/Smithsonian/ngehtsim.git@v1.0.0

--- a/sims/9vs13sims_MonitoringArray_001/README.txt
+++ b/sims/9vs13sims_MonitoringArray_001/README.txt
@@ -1,0 +1,11 @@
+The simulation in this directory aims to provide simulations and quantitative metric values for the 9m vs 13m trade study.  Specifically, this directory deals with the "monitoring array" configuration.
+
+To set up the necessary environment for running the simulation, the user must first install the Python-based ngehtsim package.  The installation requires at least Python version 3.8, and it can be carried out using the requirements.txt document by running:
+
+> pip install -r requirements.txt
+
+This simulation is then run in two parts.
+
+The first part requires running the "gendata.py" script.  This script produces a number directories containing (u,v)-coverage plots and .uvfits files capturing simulations of M87 carried out under different weather instantiations.  A geometric model for the M87 near-horizon source structure is used, though the recovered metric values have been shown to be consistent with those produced using proprietary GRMHD+GRRT simulations for the source structure.  Note: The gendata.py script will take several hours to complete on a typical laptop or desktop.
+
+After gendata.py has finished running, the "compute_metrics_monitoring_array.py" script should be run.  This script computes and prints out the various metric values appropriate for "monitoring array" operations of the array, and it produces some comparison plots.

--- a/sims/9vs13sims_MonitoringArray_001/compute_metrics_monitoring_array.py
+++ b/sims/9vs13sims_MonitoringArray_001/compute_metrics_monitoring_array.py
@@ -1,0 +1,215 @@
+#######################################################
+# imports
+
+import numpy as np
+import ngehtsim.metrics as cm
+import ehtim as eh
+import glob
+
+#######################################################
+# looped quantities
+
+outdirs = ['./array_baseline_9m+128Gbps',
+           './array_option1_13m+128Gbps',
+           './array_option2_13m+64Gbps',
+           './array_option3a_13m+128Gbps_noSPM',
+           './array_option3b_13m+128Gbps_noLCO',
+           './array_option3c_13m+128Gbps_noCNI',
+           './array_option3d_13m+128Gbps_noJELM',
+           './array_option4a_13m+64Gbps_noSPM',
+           './array_option4b_13m+64Gbps_noLCO',
+           './array_option4c_13m+64Gbps_noCNI',
+           './array_option4d_13m+64Gbps_noJELM',
+           './array_option5_13m+128Gbps_noLCO_withLLA']
+
+#######################################################
+# compute filling fractions
+
+m_100_M87 = list()
+s_100_M87 = list()
+m_1000_M87 = list()
+s_1000_M87 = list()
+m_100_SgrA = list()
+s_100_SgrA = list()
+m_1000_SgrA = list()
+s_1000_SgrA = list()
+
+for idir, outdir in enumerate(outdirs):
+
+    filelist_86_M87 = np.sort(glob.glob(outdir+'/uvfits_M87/*86GHz*uvfits'))
+    filelist_230_M87 = np.sort(glob.glob(outdir+'/uvfits_M87/*230GHz*uvfits'))
+    filelist_345_M87 = np.sort(glob.glob(outdir+'/uvfits_M87/*345GHz*uvfits'))
+
+    ff100_M87 = np.zeros(len(filelist_86_M87))
+    ff1000_M87 = np.zeros(len(filelist_86_M87))
+    for i in range(len(filelist_86_M87)):
+        with eh.parloop.HiddenPrints():
+            obs_86 = eh.obsdata.load_uvfits(filelist_86_M87[i])
+            obs_230 = eh.obsdata.load_uvfits(filelist_230_M87[i])
+            obs_345 = eh.obsdata.load_uvfits(filelist_345_M87[i])
+        obs_230.data['time'] += 0.0001
+        obs_345.data['time'] += 0.0002
+        obs = eh.obsdata.merge_obs([obs_345,obs_230,obs_86],force_merge=True)
+        ff100_M87[i] = cm.calc_ff(obs,fov=100.0,longest_BL=14.66e9)
+        ff1000_M87[i] = cm.calc_ff(obs,fov=1000.0,longest_BL=2.06e9)
+    ff100mean_M87 = np.mean(ff100_M87)
+    ff100std_M87 = np.std(ff100_M87)
+    ff1000mean_M87 = np.mean(ff1000_M87)
+    ff1000std_M87 = np.std(ff1000_M87)
+    m_100_M87.append(ff100mean_M87)
+    s_100_M87.append(ff100std_M87)
+    m_1000_M87.append(ff1000mean_M87)
+    s_1000_M87.append(ff1000std_M87)
+
+    # print
+    print('-'*40)
+    print('M87 metrics for '+outdir+':')
+    print('FF100: '+str(ff100mean_M87)+' +/- '+str(ff100std_M87))
+    print('FF1000: '+str(ff1000mean_M87)+' +/- '+str(ff1000std_M87))
+    print('-'*40)
+
+    filelist_86_SgrA = np.sort(glob.glob(outdir+'/uvfits_SgrA/*86GHz*uvfits'))
+    filelist_230_SgrA = np.sort(glob.glob(outdir+'/uvfits_SgrA/*230GHz*uvfits'))
+    filelist_345_SgrA = np.sort(glob.glob(outdir+'/uvfits_SgrA/*345GHz*uvfits'))
+
+    ff100_SgrA = np.zeros(len(filelist_86_SgrA))
+    ff1000_SgrA = np.zeros(len(filelist_86_SgrA))
+    for i in range(len(filelist_86_SgrA)):
+        with eh.parloop.HiddenPrints():
+            obs_86 = eh.obsdata.load_uvfits(filelist_86_SgrA[i])
+            obs_230 = eh.obsdata.load_uvfits(filelist_230_SgrA[i])
+            obs_345 = eh.obsdata.load_uvfits(filelist_345_SgrA[i])
+        obs_230.data['time'] += 0.0001
+        obs_345.data['time'] += 0.0002
+        obs = eh.obsdata.merge_obs([obs_345,obs_230,obs_86],force_merge=True)
+        ff100_SgrA[i] = cm.calc_ff(obs,fov=100.0,longest_BL=14.66e9)
+        ff1000_SgrA[i] = cm.calc_ff(obs,fov=1000.0,longest_BL=2.06e9)
+    ff100mean_SgrA = np.mean(ff100_SgrA)
+    ff100std_SgrA = np.std(ff100_SgrA)
+    ff1000mean_SgrA = np.mean(ff1000_SgrA)
+    ff1000std_SgrA = np.std(ff1000_SgrA)
+    m_100_SgrA.append(ff100mean_SgrA)
+    s_100_SgrA.append(ff100std_SgrA)
+    m_1000_SgrA.append(ff1000mean_SgrA)
+    s_1000_SgrA.append(ff1000std_SgrA)
+
+    # print
+    print('-'*40)
+    print('Sgr A* metrics for '+outdir+':')
+    print('FF100: '+str(ff100mean_SgrA)+' +/- '+str(ff100std_SgrA))
+    print('FF1000: '+str(ff1000mean_SgrA)+' +/- '+str(ff1000std_SgrA))
+    print('-'*40)
+
+#######################################################
+# plot things
+
+import matplotlib.pyplot as plt
+
+plt.rcParams.update({
+    "text.usetex": True,
+    "font.family": "serif",
+    "font.serif": ["Times"],
+    "font.size": 10})
+
+#######################################################
+# plot M87
+
+base_m_100 = m_100_M87[0]
+base_s_100 = s_100_M87[0]
+base_m_1000 = m_1000_M87[0]
+base_s_1000 = s_1000_M87[0]
+
+m_100 = np.array(m_100_M87[1:])
+s_100 = np.array(s_100_M87[1:])
+m_1000 = np.array(m_1000_M87[1:])
+s_1000 = np.array(s_1000_M87[1:])
+
+m_100_frac = 100.0*((m_100 - base_m_100)/base_m_100)
+s_100_frac = 100.0*(s_100/base_m_100)
+m_1000_frac = 100.0*((m_1000 - base_m_1000)/base_m_1000)
+s_1000_frac = 100.0*(s_1000/base_m_1000)
+
+s_100_frac_base = 100.0*(base_s_100 / base_m_100)
+s_1000_frac_base = 100.0*(base_s_1000 / base_m_1000)
+
+fig = plt.figure(figsize=(8,2))
+ax1 = fig.add_axes([0.1,0.1,0.8,0.4])
+ax2 = fig.add_axes([0.1,0.5,0.8,0.4])
+
+x = np.linspace(1.0,len(m_100),len(m_100))
+
+ax2.fill_between([0,20],[-s_100_frac_base,-s_100_frac_base],[s_100_frac_base,s_100_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax2.plot([0,20],[0.0,0.0],'k--')
+ax2.errorbar(x,m_100_frac,yerr=s_100_frac,fmt='bo',markersize=4)
+
+ax1.fill_between([0,20],[-s_1000_frac_base,-s_1000_frac_base],[s_1000_frac_base,s_1000_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax1.plot([0,20],[0.0,0.0],'k--')
+ax1.errorbar(x,m_1000_frac,yerr=s_1000_frac,fmt='bo',markersize=4)
+
+ax1.set_xlim(0,len(m_100)+1)
+ax1.set_ylim(-11,11)
+ax2.set_xlim(0,len(m_100)+1)
+ax2.set_ylim(-30,30)
+
+ax1.set_ylabel(r'$\Delta$FF1000 (\%)')
+ax2.set_ylabel(r'$\Delta$FF100 (\%)')
+
+ax1.set_xticks(x)
+ax2.set_xticks(x)
+ax1.set_xticklabels(['Option 1', 'Option 2', 'Option 3a\n(no SPM)', 'Option 3b\n(no LCO)', 'Option 3c\n(no CNI)', 'Option 3d\n(no JELM)', 'Option 4a\n(no SPM)', 'Option 4b\n(no LCO)', 'Option 4c\n(no CNI)', 'Option 4d\n(no JELM)', 'Option 5'],rotation=60,ha='center')
+ax2.set_xticklabels([])
+
+plt.savefig('comparison_M87.png',dpi=300,bbox_inches='tight')
+plt.close()
+
+#######################################################
+# plot SgrA
+
+base_m_100 = m_100_SgrA[0]
+base_s_100 = s_100_SgrA[0]
+base_m_1000 = m_1000_SgrA[0]
+base_s_1000 = s_1000_SgrA[0]
+
+m_100 = np.array(m_100_SgrA[1:])
+s_100 = np.array(s_100_SgrA[1:])
+m_1000 = np.array(m_1000_SgrA[1:])
+s_1000 = np.array(s_1000_SgrA[1:])
+
+m_100_frac = 100.0*((m_100 - base_m_100)/base_m_100)
+s_100_frac = 100.0*(s_100/base_m_100)
+m_1000_frac = 100.0*((m_1000 - base_m_1000)/base_m_1000)
+s_1000_frac = 100.0*(s_1000/base_m_1000)
+
+s_100_frac_base = 100.0*(base_s_100 / base_m_100)
+s_1000_frac_base = 100.0*(base_s_1000 / base_m_1000)
+
+fig = plt.figure(figsize=(8,2))
+ax1 = fig.add_axes([0.1,0.1,0.8,0.4])
+ax2 = fig.add_axes([0.1,0.5,0.8,0.4])
+
+x = np.linspace(1.0,len(m_100),len(m_100))
+
+ax2.fill_between([0,20],[-s_100_frac_base,-s_100_frac_base],[s_100_frac_base,s_100_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax2.plot([0,20],[0.0,0.0],'k--')
+ax2.errorbar(x,m_100_frac,yerr=s_100_frac,fmt='bo',markersize=4)
+
+ax1.fill_between([0,20],[-s_1000_frac_base,-s_1000_frac_base],[s_1000_frac_base,s_1000_frac_base],color='gray',alpha=0.3,linewidth=0)
+ax1.plot([0,20],[0.0,0.0],'k--')
+ax1.errorbar(x,m_1000_frac,yerr=s_1000_frac,fmt='bo',markersize=4)
+
+ax1.set_xlim(0,len(m_100)+1)
+ax1.set_ylim(-30,30)
+ax2.set_xlim(0,len(m_100)+1)
+ax2.set_ylim(-15,15)
+
+ax1.set_ylabel(r'$\Delta$FF1000 (\%)')
+ax2.set_ylabel(r'$\Delta$FF100 (\%)')
+
+ax1.set_xticks(x)
+ax2.set_xticks(x)
+ax1.set_xticklabels(['Option 1', 'Option 2', 'Option 3a\n(no SPM)', 'Option 3b\n(no LCO)', 'Option 3c\n(no CNI)', 'Option 3d\n(no JELM)', 'Option 4a\n(no SPM)', 'Option 4b\n(no LCO)', 'Option 4c\n(no CNI)', 'Option 4d\n(no JELM)', 'Option 5'],rotation=60,ha='center')
+ax2.set_xticklabels([])
+
+plt.savefig('comparison_SgrA.png',dpi=300,bbox_inches='tight')
+plt.close()
+

--- a/sims/9vs13sims_MonitoringArray_001/gendata.py
+++ b/sims/9vs13sims_MonitoringArray_001/gendata.py
@@ -1,0 +1,575 @@
+#######################################################
+# imports
+
+import numpy as np
+import matplotlib.pyplot as plt
+import ngehtsim.obs.obs_generator as og
+import ngehtsim.metrics as cm
+import ehtim as eh
+import ehtim.scattering as so
+import os
+
+#######################################################
+# looped quantities
+
+outdirs = ['./array_baseline_9m+128Gbps',
+           './array_option1_13m+128Gbps',
+           './array_option2_13m+64Gbps',
+           './array_option3a_13m+128Gbps_noSPM',
+           './array_option3b_13m+128Gbps_noLCO',
+           './array_option3c_13m+128Gbps_noCNI',
+           './array_option3d_13m+128Gbps_noJELM',
+           './array_option4a_13m+64Gbps_noSPM',
+           './array_option4b_13m+64Gbps_noLCO',
+           './array_option4c_13m+64Gbps_noCNI',
+           './array_option4d_13m+64Gbps_noJELM',
+           './array_option5_13m+128Gbps_noLCO_withLLA']
+
+sitess = [['BAJA','CNI','GLT','HAY','JCMT','JELM','KP','LAS','OVRO','SMT','SPT'],
+          ['BAJA','CNI','GLT','HAY','JCMT','JELM','KP','LAS','OVRO','SMT','SPT'],
+          ['BAJA','CNI','GLT','HAY','JCMT','JELM','KP','LAS','OVRO','SMT','SPT'],
+          ['CNI','GLT','HAY','JCMT','JELM','KP','LAS','OVRO','SMT','SPT'],
+          ['BAJA','CNI','GLT','HAY','JCMT','JELM','KP','OVRO','SMT','SPT'],
+          ['BAJA','GLT','HAY','JCMT','JELM','KP','LAS','OVRO','SMT','SPT'],
+          ['BAJA','CNI','GLT','HAY','JCMT','KP','LAS','OVRO','SMT','SPT'],
+          ['CNI','GLT','HAY','JCMT','JELM','KP','LAS','OVRO','SMT','SPT'],
+          ['BAJA','CNI','GLT','HAY','JCMT','JELM','KP','OVRO','SMT','SPT'],
+          ['BAJA','GLT','HAY','JCMT','JELM','KP','LAS','OVRO','SMT','SPT'],
+          ['BAJA','CNI','GLT','HAY','JCMT','KP','LAS','OVRO','SMT','SPT'],
+          ['BAJA','CNI','GLT','HAY','JCMT','JELM','KP','LLA','OVRO','SMT','SPT']]
+
+dish_diameters = [9.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0,
+                  13.0]
+
+bandwidths = [16.0,
+              16.0,
+              8.0,
+              16.0,
+              16.0,
+              16.0,
+              16.0,
+              8.0,
+              8.0,
+              8.0,
+              8.0,
+              16.0]
+
+#######################################################
+# make source model for M87
+
+F0 = 0.6
+f0 = 0.9
+f1 = 0.1
+alpha = 15.0
+alpha2 = 1.5
+
+mod = eh.model.Model()
+mod = mod.add_thick_mring(F0=f0*F0,
+                          d=42.0*eh.RADPERUAS,
+                          alpha=alpha*eh.RADPERUAS,
+                          beta_list=[-0.4])
+mod = mod.add_thick_mring(F0=f1*F0,
+                          d=42.0*eh.RADPERUAS,
+                          alpha=alpha2*eh.RADPERUAS,
+                          beta_list=[-0.4])
+
+# save as image
+im = mod.make_image(500.0*eh.RADPERUAS,npix=512)
+im.save_fits('./M87.fits')
+
+#######################################################
+# make source model for Sgr A*
+
+F0 = 2.5
+f0 = 0.9
+d = 52.0
+alpha = 20.0
+b1a = 0.15
+b2a = 0.06
+b3a = 0.25
+b4a = 0.13
+b1p = 0.0
+b2p = -2.3
+b3p = 0.5
+b4p = -1.4
+
+alpha1 = 2.0
+f1 = 0.1
+
+beta1 = b1a*np.exp((1j)*(b1p*np.pi))
+beta2 = b2a*np.exp((1j)*(b2p*np.pi))
+beta3 = b3a*np.exp((1j)*(b3p*np.pi))
+beta4 = b4a*np.exp((1j)*(b4p*np.pi))
+stretch = 1.2
+stretch_PA = (np.pi/2.0) - 0.2
+
+mod = eh.model.Model()
+mod = mod.add_stretched_thick_mring(F0=f0*F0,
+                                    d=d*eh.RADPERUAS,
+                                    alpha=alpha*eh.RADPERUAS,
+                                    x0=0.0,
+                                    y0=0.0,
+                                    beta_list=[beta1,beta2,beta3,beta4],
+                                    stretch=stretch,
+                                    stretch_PA=stretch_PA)
+mod = mod.add_stretched_thick_mring(F0=f1*F0,
+                                    d=d*eh.RADPERUAS,
+                                    alpha=alpha1*eh.RADPERUAS,
+                                    x0=0.0,
+                                    y0=0.0,
+                                    beta_list=[beta1,beta2,beta3,beta4],
+                                    stretch=1.0,
+                                    stretch_PA=stretch_PA)
+
+
+# save as image
+im = mod.make_image(1000.0*eh.RADPERUAS,npix=1024)
+im.RA = 17.761122
+im.DEC = -29.00781
+im.source = 'SgrA'
+
+im.rf = 86.0e9
+im_scatt = sm.Scatter(im)
+im_scatt.save_fits('SgrA_86GHz.fits')
+
+im.rf = 230.0e9
+im_scatt = sm.Scatter(im)
+im_scatt.save_fits('SgrA_230GHz.fits')
+
+im.rf = 345.0e9
+im_scatt = sm.Scatter(im)
+im_scatt.save_fits('SgrA_345GHz.fits')
+
+#######################################################
+# primary settings
+
+Nweather = 100
+SNR_cut = 3.0
+
+freqs = [86.0, 230.0, 345.0]
+input_models_M87 = ['./M87.fits', './M87.fits', './M87.fits']
+input_models_SgrA = ['./SgrA_86GHz.fits', './SgrA_230GHz.fits', './SgrA_345GHz.fits']
+
+receiver_configuration_overrides = {'ALMA': ['Band7'],
+                                    'APEX': ['Band7'],
+                                    'BAJA': ['Band3', 'Band6', 'Band7'],
+                                    'CNI': ['Band3', 'Band6', 'Band7'],
+                                    'GLT': ['Band3', 'Band6', 'Band7'],
+                                    'HAY': ['Band3', 'Band6'],
+                                    'IRAM': ['Band7'],
+                                    'JCMT': ['Band3', 'Band6', 'Band7'],
+                                    'JELM': ['Band3', 'Band6', 'Band7'],
+                                    'KP': ['Band3', 'Band6'],
+                                    'LAS': ['Band3', 'Band6', 'Band7'],
+                                    'LMT': ['Band3', 'Band6', 'Band7'],
+                                    'NOEMA': ['Band7'],
+                                    'OVRO': ['Band3', 'Band6'],
+                                    'SMA': ['Band7'],
+                                    'SMT': ['Band3', 'Band6', 'Band7'],
+                                    'SPT': ['Band3', 'Band6', 'Band7']}
+
+# overrides
+T_R_overrides = {'ALMA': {'Band7': 75.0},
+                 'APEX': {'Band7': 75.0},
+                 'GLT': {'Band7': 75.0},
+                 'IRAM': {'Band7': 85.0},
+                 'JCMT': {'Band7': 105.0},
+                 'LMT': {'Band7': 75.0},
+                 'NOEMA': {'Band7': 85.0},
+                 'SMA': {'Band7': 130.0},
+                 'SMT': {'Band7': 150.0}}
+
+bandwidth_overrides = {'ALMA': {'Band7': 4.0},
+                       'APEX': {'Band7': 4.0},
+                       'IRAM': {'Band7': 4.0},
+                       'NOEMA': {'Band7': 4.0},
+                       'SMA': {'Band7': 4.0}}
+
+# specify the DSB stations
+sideband_ratio_overrides = {'SMA': {'Band7': 1.0},
+                            'SMT': {'Band7': 1.0}}
+
+#######################################################
+# run multiple weather instantiations
+
+for idir in range(len(outdirs)):
+
+    # grab current parameters
+    outdir = outdirs[idir]
+    sites = sitess[idir]
+    dish_diameter = dish_diameters[idir]
+    bandwidth = bandwidths[idir]
+
+    # make output directory
+    os.makedirs(outdir,exist_ok=True)
+    os.makedirs(outdir+'/uvfits_M87',exist_ok=True)
+    os.makedirs(outdir+'/uvfits_SgrA',exist_ok=True)
+
+    #######################################################
+    # M87 simulations
+
+    # update settings and overrides
+    settings = {'model_file': input_models_M87[-1],
+                'sites': sites,
+                'source': 'M87',
+                'frequency': freqs[-1],
+                'bandwidth': bandwidth,
+                'month': 'Apr',
+                'day': 15,
+                'year': 2021,
+                't_start': 0.0,
+                'dt': 24.0,
+                't_int': 300.0,
+                't_rest': 600.0,
+                'D_new': dish_diameter,
+                'fringe_finder': ['fringegroups', [5., 5.]],
+                'weather': 'random'}
+
+    D_overrides = {'BAJA': dish_diameter,
+                   'CNI': dish_diameter,
+                   'JELM': dish_diameter,
+                   'LAS': dish_diameter}
+
+    # run multiple weather instantiations
+    obslist_M87 = list()
+    fflist = list()
+    for i in range(Nweather):
+        print(i)
+
+        settings.update({'random_seed': 101 + i})
+        obsgen = og.obs_generator(settings,
+                              D_overrides=D_overrides,
+                              receiver_configuration_overrides=receiver_configuration_overrides,
+                              T_R_overrides=T_R_overrides,
+                              bandwidth_overrides=bandwidth_overrides,
+                              sideband_ratio_overrides=sideband_ratio_overrides)
+        obslist_here = obsgen.make_obs_mf(freqs,input_models_M87,addnoise=False,addgains=False)
+
+        if (SNR_cut > 0.0):
+            obslist_here[0] = obslist_here[0].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[1] = obslist_here[1].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[2] = obslist_here[2].flag_low_snr(snr_cut=SNR_cut).copy()
+
+        obslist_M87.append(obslist_here)
+
+        ff86 = cm.calc_ff(obslist_here[0],fov=100.0,longest_BL=14.66e9)
+        ff230 = cm.calc_ff(obslist_here[1],fov=100.0,longest_BL=14.66e9)
+        ff345 = cm.calc_ff(obslist_here[2],fov=100.0,longest_BL=14.66e9)
+        fflist.append([ff86,ff230,ff345])
+
+        # save uvfits
+        obslist_M87[i][0].save_uvfits(outdir+'/uvfits_M87/obs_86GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][1].save_uvfits(outdir+'/uvfits_M87/obs_230GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][2].save_uvfits(outdir+'/uvfits_M87/obs_345GHz_'+str(i).zfill(4)+'.uvfits')
+
+    # no noise obs
+    settings.update({'frequency': 86.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_86 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_86 = obsgen_nonoise_86.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_86 = obs_nonoise_86.data['u'] / (1.0e9)
+    v_nonoise_86 = obs_nonoise_86.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 230.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_230 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_230 = obsgen_nonoise_230.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_230 = obs_nonoise_230.data['u'] / (1.0e9)
+    v_nonoise_230 = obs_nonoise_230.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 345.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_345 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_345 = obsgen_nonoise_345.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_345 = obs_nonoise_345.data['u'] / (1.0e9)
+    v_nonoise_345 = obs_nonoise_345.data['v'] / (1.0e9)
+
+    #################
+    # plot
+
+    fig = plt.figure(figsize=(4,4))
+    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+
+    weight_86 = np.zeros_like(u_nonoise_86)
+    for j in range(Nweather):
+        obshere_86 = obslist_M87[j][0].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+        obshere_86 = obslist_M87[j][0].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+    weight_86 /= Nweather
+
+    weight_230 = np.zeros_like(u_nonoise_230)
+    for j in range(Nweather):
+        obshere_230 = obslist_M87[j][1].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+        obshere_230 = obslist_M87[j][1].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+    weight_230 /= Nweather
+
+    weight_345 = np.zeros_like(u_nonoise_345)
+    for j in range(Nweather):
+        obshere_345 = obslist_M87[j][2].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+        obshere_345 = obslist_M87[j][2].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+    weight_345 /= Nweather
+
+    for i in range(len(u_nonoise_345)):
+        ax.plot([u_nonoise_345[i]],[v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+        ax.plot([-u_nonoise_345[i]],[-v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+    for i in range(len(u_nonoise_230)):
+        ax.plot([u_nonoise_230[i]],[v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+        ax.plot([-u_nonoise_230[i]],[-v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+    for i in range(len(u_nonoise_86)):
+        ax.plot([u_nonoise_86[i]],[v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+        ax.plot([-u_nonoise_86[i]],[-v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+
+    # dummy legend point
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,label='345 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,label='230 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,label='86 GHz')
+    ax.legend(loc='lower left',fontsize=8)
+
+    ax.set_xlim(15,-15)
+    ax.set_ylim(-15,15)
+
+    ax.set_xlabel(r'$u$ (G$\lambda$)')
+    ax.set_ylabel(r'$v$ (G$\lambda$)')
+
+    ax.grid(linewidth=0.5,color='gray',alpha=0.2,linestyle='--')
+
+    plt.savefig(outdir+'/coverage_M87.png',dpi=300,bbox_inches='tight')
+    plt.close()
+
+    #################
+    # fill fraction
+
+    ffmeans = np.mean(np.array(fflist),axis=0)
+    ffstds = np.std(np.array(fflist),axis=0)
+
+    ff_86 = ffmeans[0]
+    ff_230 = ffmeans[1]
+    ff_345 = ffmeans[2]
+
+    print('-'*40)
+    print('M87 FF at 86 GHz: '+str(ff_86)+' +/- '+str(ffstds[0]))
+    print('M87 FF at 230 GHz: '+str(ff_230)+' +/- '+str(ffstds[1]))
+    print('M87 FF at 345 GHz: '+str(ff_345)+' +/- '+str(ffstds[2]))
+    print('-'*40)
+
+    #######################################################
+    # Sgr A* simulations
+
+    # update settings and overrides
+    settings = {'model_file': input_models_SgrA[-1],
+                'sites': sites,
+                'source': 'SgrA',
+                'frequency': freqs[-1],
+                'bandwidth': bandwidth,
+                'month': 'Apr',
+                'day': 15,
+                'year': 2021,
+                't_start': 0.0,
+                'dt': 24.0,
+                't_int': 300.0,
+                't_rest': 600.0,
+                'D_new': dish_diameter,
+                'fringe_finder': ['fringegroups', [5., 5.]],
+                'weather': 'random'}
+
+    D_overrides = {'BAJA': dish_diameter,
+                   'CNI': dish_diameter,
+                   'JELM': dish_diameter,
+                   'LAS': dish_diameter}
+
+    # run multiple weather instantiations
+    obslist_M87 = list()
+    fflist = list()
+    for i in range(Nweather):
+        print(i)
+
+        settings.update({'random_seed': 101 + i})
+        obsgen = og.obs_generator(settings,
+                              D_overrides=D_overrides,
+                              receiver_configuration_overrides=receiver_configuration_overrides,
+                              T_R_overrides=T_R_overrides,
+                              bandwidth_overrides=bandwidth_overrides,
+                              sideband_ratio_overrides=sideband_ratio_overrides)
+        obslist_here = obsgen.make_obs_mf(freqs,input_models_SgrA,addnoise=False,addgains=False)
+
+        if (SNR_cut > 0.0):
+            obslist_here[0] = obslist_here[0].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[1] = obslist_here[1].flag_low_snr(snr_cut=SNR_cut).copy()
+            obslist_here[2] = obslist_here[2].flag_low_snr(snr_cut=SNR_cut).copy()
+
+        obslist_M87.append(obslist_here)
+
+        ff86 = cm.calc_ff(obslist_here[0],fov=100.0,longest_BL=14.66e9)
+        ff230 = cm.calc_ff(obslist_here[1],fov=100.0,longest_BL=14.66e9)
+        ff345 = cm.calc_ff(obslist_here[2],fov=100.0,longest_BL=14.66e9)
+        fflist.append([ff86,ff230,ff345])
+
+        # save uvfits
+        obslist_M87[i][0].save_uvfits(outdir+'/uvfits_M87/obs_86GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][1].save_uvfits(outdir+'/uvfits_M87/obs_230GHz_'+str(i).zfill(4)+'.uvfits')
+        obslist_M87[i][2].save_uvfits(outdir+'/uvfits_M87/obs_345GHz_'+str(i).zfill(4)+'.uvfits')
+
+    # no noise obs
+    settings.update({'frequency': 86.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_86 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_86 = obsgen_nonoise_86.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_86 = obs_nonoise_86.data['u'] / (1.0e9)
+    v_nonoise_86 = obs_nonoise_86.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 230.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_230 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_230 = obsgen_nonoise_230.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_230 = obs_nonoise_230.data['u'] / (1.0e9)
+    v_nonoise_230 = obs_nonoise_230.data['v'] / (1.0e9)
+
+    settings.update({'frequency': 345.0,
+                     'fringe_finder': ['naive', 0.0]})
+    obsgen_nonoise_345 = og.obs_generator(settings,
+                                      D_overrides=D_overrides,
+                                      receiver_configuration_overrides=receiver_configuration_overrides,
+                                      T_R_overrides=T_R_overrides,
+                                      bandwidth_overrides=bandwidth_overrides,
+                                      sideband_ratio_overrides=sideband_ratio_overrides)
+    obs_nonoise_345 = obsgen_nonoise_345.make_obs(addnoise=False,addgains=False,flagwind=False)
+    u_nonoise_345 = obs_nonoise_345.data['u'] / (1.0e9)
+    v_nonoise_345 = obs_nonoise_345.data['v'] / (1.0e9)
+
+    #################
+    # plot
+
+    fig = plt.figure(figsize=(4,4))
+    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+
+    weight_86 = np.zeros_like(u_nonoise_86)
+    for j in range(Nweather):
+        obshere_86 = obslist_M87[j][0].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+        obshere_86 = obslist_M87[j][0].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_86)):
+            if (u_nonoise_86[i] in (obshere_86.data['u'] / (1.0e9))):
+                weight_86[i] += 1.0
+    weight_86 /= Nweather
+
+    weight_230 = np.zeros_like(u_nonoise_230)
+    for j in range(Nweather):
+        obshere_230 = obslist_M87[j][1].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+        obshere_230 = obslist_M87[j][1].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_230)):
+            if (u_nonoise_230[i] in (obshere_230.data['u'] / (1.0e9))):
+                weight_230[i] += 1.0
+    weight_230 /= Nweather
+
+    weight_345 = np.zeros_like(u_nonoise_345)
+    for j in range(Nweather):
+        obshere_345 = obslist_M87[j][2].flag_sites(['SMA','APEX'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+        obshere_345 = obslist_M87[j][2].flag_sites(['BAJA','CNI','GLT','HAY','IRAM','JCMT','JELM','KP','LAS','LLA','LMT','NOEMA','OVRO','SMA','SMT','SPT'])
+        for i in range(len(u_nonoise_345)):
+            if (u_nonoise_345[i] in (obshere_345.data['u'] / (1.0e9))):
+                weight_345[i] += 1.0
+    weight_345 /= Nweather
+
+    for i in range(len(u_nonoise_345)):
+        ax.plot([u_nonoise_345[i]],[v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+        ax.plot([-u_nonoise_345[i]],[-v_nonoise_345[i]],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,alpha=weight_345[i])
+    for i in range(len(u_nonoise_230)):
+        ax.plot([u_nonoise_230[i]],[v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+        ax.plot([-u_nonoise_230[i]],[-v_nonoise_230[i]],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,alpha=weight_230[i])
+    for i in range(len(u_nonoise_86)):
+        ax.plot([u_nonoise_86[i]],[v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+        ax.plot([-u_nonoise_86[i]],[-v_nonoise_86[i]],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,alpha=weight_86[i])
+
+    # dummy legend point
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='green',markeredgewidth=0,markersize=2,label='345 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='orange',markeredgewidth=0,markersize=2,label='230 GHz')
+    ax.plot([-99],[-99],marker='o',linewidth=0,color='purple',markeredgewidth=0,markersize=2,label='86 GHz')
+    ax.legend(loc='lower left',fontsize=8)
+
+    ax.set_xlim(15,-15)
+    ax.set_ylim(-15,15)
+
+    ax.set_xlabel(r'$u$ (G$\lambda$)')
+    ax.set_ylabel(r'$v$ (G$\lambda$)')
+
+    ax.grid(linewidth=0.5,color='gray',alpha=0.2,linestyle='--')
+
+    plt.savefig(outdir+'/coverage_M87.png',dpi=300,bbox_inches='tight')
+    plt.close()
+
+    #################
+    # fill fraction
+
+    ffmeans = np.mean(np.array(fflist),axis=0)
+    ffstds = np.std(np.array(fflist),axis=0)
+
+    ff_86 = ffmeans[0]
+    ff_230 = ffmeans[1]
+    ff_345 = ffmeans[2]
+
+    print('-'*40)
+    print('Sgr A* FF at 86 GHz: '+str(ff_86)+' +/- '+str(ffstds[0]))
+    print('Sgr A* FF at 230 GHz: '+str(ff_230)+' +/- '+str(ffstds[1]))
+    print('Sgr A* FF at 345 GHz: '+str(ff_345)+' +/- '+str(ffstds[2]))
+    print('-'*40)
+

--- a/sims/9vs13sims_MonitoringArray_001/requirements.txt
+++ b/sims/9vs13sims_MonitoringArray_001/requirements.txt
@@ -1,0 +1,1 @@
+ngehtsim @ git+https://github.com/Smithsonian/ngehtsim.git@v1.0.0


### PR DESCRIPTION
This branch contains some simulations that provide metric values used in the 9m vs 13m trade study. Specifically, it quantifies the filling fraction for the full and monitoring arrays when observing M87 and Sgr A*, and it compares various potential variants of the array in terms of dish size, recording rate, and station choices.